### PR TITLE
Updated resolver to lts-18.28

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -1,5 +1,6 @@
 import           Control.Monad.Trans
 import           System.Console.Haskeline
+import           Control.Exception
 import qualified Language.Nano.Types  as Nano
 import qualified Language.Nano.Eval   as Nano
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-14.12
+resolver: lts-18.28
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
- Updated Main.hs: for some reason it requires "import Control.Exception" for `catch` in lts-18.28.